### PR TITLE
Cylinder sampling

### DIFF
--- a/configs/dataset/base.yaml
+++ b/configs/dataset/base.yaml
@@ -2,7 +2,8 @@
 
 path: data/${dataset.name}.zip
 c_dim: 0
-camera: ~ # You must define it explicitly
+camera:
+  dist_type: spherical
 
 # Default parameters
 resolution: 256

--- a/src/train.py
+++ b/src/train.py
@@ -226,6 +226,9 @@ def main(cfg: DictConfig):
             c.G_kwargs.channel_max *= 2
             c.G_kwargs.use_radial_filters = True # Use radially symmetric downsampling filters.
 
+        # In case of cfg.dataset.camera.dist_type='cylindrical', this would not work as intended
+        # So comment this out in case it's bothering you
+        # And you are sure all camera parameters are correctly tweaked
         print('Validating that the vieweing frustum is inside the cube...', end='')
         assert validate_frustum(
             fov=cfg.dataset.camera.fov,


### PR DESCRIPTION
This implementation of cylindrical sampling assumes that `cfg.dataset.camera.dist=custom`
Otherwise, `sample_camera_angles_cylindrical` has to be implemented